### PR TITLE
reduce log verbosity 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ example/firehose/log/*
 *~
 
 *.sw[a-p]
+
+.ropeproject

--- a/streams/client.go
+++ b/streams/client.go
@@ -94,7 +94,7 @@ func (client *client) publishEvents(events []publisher.Event) ([]publisher.Event
 		observer.Dropped(dropped)
 		observer.Acked(len(okEvents))
 		if len(records) == 0 {
-			logp.Info("kinesis", "No records were mapped")
+			logp.Debug("kinesis", "No records were mapped")
 			return nil, nil
 		}
 	}


### PR DESCRIPTION
This is so that we could emit the periodic metric logs (INFO) without drowning in log lines whenever no records are mapped (e.g. when we are swamped with invalid records).